### PR TITLE
perf: incremental local updates and threaded sweep for OLIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@
 - Updated to the new `DynamicalSystemsBase` interface; `StochasticSystemsBase`
   is no longer used (#335).
 - Switched code formatter to Runic.jl (#315).
+- `quasipotential` is 32-154x faster (`61x61`, `band_radius=12`, rank-1 oscillator:
+  `17.9 s` to `0.12 s`). Each heap pop now updates a neighbour only from the simplexes
+  the popped cell just created rather than rescanning every front simplex in its
+  stencil, and the independent per-pop updates are spread over the available threads
+  (new `threaded=true` keyword, bitwise identical to the serial sweep). Cost now grows
+  like `band_radius^1.6` rather than the stencil volume. Two further changes are bitwise
+  exact: the edge root find reuses the endpoint values it already computed, and slope
+  limiting is hoisted out of the per-λ Hermite evaluation. The incremental update is
+  *not* bitwise identical to the previous full rescan. It can only leave `U` higher,
+  which is consistent with the method's documented upper-bound property, and it raises
+  `U` in 99.9% of cells by `0.04-0.14 %` of scale; pass `_full_rescan=true` to recover
+  the old candidate set.
 
 #### Fixed
 - Freidlin-Wentzell action conventions and stray `/2` factors (#329).

--- a/benchmarks/quasipotential.jl
+++ b/benchmarks/quasipotential.jl
@@ -38,5 +38,20 @@ function benchmark_quasipotential!(SUITE)
         CartesianGrid((-1.0, 1.0, 81), (-1.0, 1.0, 81)),
         [0.0, 0.0]; show_progress = false,
     ) seconds = 30
+
+    # 2D rank-1 (momentum-only) noise: the anisotropic metric is the expensive case and
+    # the one real second-order Langevin problems hit. Runs serially so the timing is a
+    # measure of the sweep rather than of the host's core count.
+    lin_osc(u, p, t) = SA[u[2], -u[1] - 0.5 * u[2]]
+    osc_g(u, p, t) = SA[0.0, 1.0]
+    sys_r1 = CoupledSDEs(lin_osc, [0.0, 0.0]; g = osc_g, noise_strength = 1.0)
+    SUITE["Large deviation"]["Quasipotential"]["OLIM, rank-1 oscillator 61x61 K=12"] =
+        @benchmarkable quasipotential(
+        $sys_r1,
+        CartesianGrid((-1.5, 1.5, 61), (-1.5, 1.5, 61)),
+        [0.0, 0.0];
+        band_radius = 12, regularization = 0.005,
+        show_progress = false, threaded = false,
+    ) seconds = 60
     return nothing
 end

--- a/src/largedeviations/quasipotential/lagrangian.jl
+++ b/src/largedeviations/quasipotential/lagrangian.jl
@@ -1,10 +1,15 @@
 """
-    itp_root(f, a, b; k1, k2, n0, atol, maxiter) -> (root::T, converged::Bool)
+    itp_root(f, a, b; k1, k2, n0, atol, maxiter, fa, fb) -> (root::T, converged::Bool)
 
 Interpolate-Truncate-Project bracketed scalar root-find (Oliveira and Takahashi 2020,
 ACM TOMS 47:1). Returns `(root, true)` if a sign change is bracketed; returns the
 endpoint with smaller `|f|` and `false` when `f(a) * f(b) > 0`, signalling no
 interior root.
+
+`fa`/`fb` let a caller that already knows the endpoint values pass them in rather
+than pay for `f(a)`/`f(b)` again. That matters here because `f` is a finite-difference
+derivative, so each endpoint evaluation costs two evaluations of the underlying
+function.
 """
 @inline function itp_root(
         f, a::T, b::T;
@@ -12,8 +17,8 @@ interior root.
         n0::Int = 1,
         atol::T = eps(T)^(T(3) / T(4)),
         maxiter::Int = 64,
+        fa::T = f(a), fb::T = f(b),
     ) where {T <: AbstractFloat}
-    fa = f(a); fb = f(b)
     iszero(fa) && return (a, true)
     iszero(fb) && return (b, true)
     if fa * fb > 0
@@ -292,9 +297,49 @@ end
     L::_GeometricLagrangian{D, T}, y::SVector{D, S}, v::SVector{D, S}, _nd0, _nd1,
 ) where {D, T, S} = _line_integral(L, y, v)
 
-@inline function _hermite_U(U0::T, U1::T, m0::T, m1::T, λ::T) where {T}
+"""
+Fritsch-Carlson slope limiter. Clamping both slopes into `[0, 3Δ]` (`Δ = U1 - U0`,
+oriented) is sufficient for the Hermite cubic to be monotone on `[0, 1]`, hence to
+satisfy `H(λ) ∈ [min(U0, U1), max(U0, U1)]`.
+
+Without it the interpolant overshoots and, more damagingly, *undershoots*: an
+unlimited cubic with `U0 = U1 = 0`, `m0 = -a`, `m1 = a` gives `H(λ) = -a λ(1 - λ)`,
+i.e. `-a/4` at the midpoint. Since the local update adds a nonnegative line integral
+to this value, an undershooting interpolant is the only way the sweep can return
+`U < 0`, or an update that undercuts every accepted value it was built from. Slopes
+are one-sided divided differences of a field known only to `O(h)`, so they routinely
+disagree in sign with the secant and trigger exactly that case.
+"""
+@inline function _limit_slopes(U0::T, U1::T, s0::T, s1::T) where {T}
+    Δ = U1 - U0
+    iszero(Δ) && return (zero(T), zero(T))
+    lo, hi = Δ > zero(T) ? (zero(T), T(3) * Δ) : (T(3) * Δ, zero(T))
+    return (clamp(s0, lo, hi), clamp(s1, lo, hi))
+end
+
+"""
+Substitute the secant for a missing (`NaN`) slope estimate, then limit. Depends only
+on the edge data, not on `λ`, so callers that evaluate the interpolant repeatedly along
+one edge hoist this out of the loop (see `_edge_minimum`) rather than redoing the
+`isnan` branches and the clamp at every `λ`.
+"""
+@inline function _prepare_slopes(U0::T, U1::T, m0::T, m1::T) where {T}
     s0 = isnan(m0) ? (U1 - U0) : m0
     s1 = isnan(m1) ? (U1 - U0) : m1
+    return _limit_slopes(U0, U1, s0, s1)
+end
+
+# Hermite cubic on already-prepared (secant-substituted and limited) slopes.
+@inline function _hermite_prepared(U0::T, U1::T, s0::T, s1::T, λ::T) where {T}
+    h00 = T(2) * λ^3 - T(3) * λ^2 + one(T)
+    h10 = λ^3 - T(2) * λ^2 + λ
+    h01 = -T(2) * λ^3 + T(3) * λ^2
+    h11 = λ^3 - λ^2
+    return h00 * U0 + h10 * s0 + h01 * U1 + h11 * s1
+end
+
+@inline function _hermite_U(U0::T, U1::T, m0::T, m1::T, λ::T) where {T}
+    s0, s1 = _prepare_slopes(U0, U1, m0, m1)
     h00 = T(2) * λ^3 - T(3) * λ^2 + one(T)
     h10 = λ^3 - T(2) * λ^2 + λ
     h01 = -T(2) * λ^3 + T(3) * λ^2

--- a/src/largedeviations/quasipotential/quasipotential.jl
+++ b/src/largedeviations/quasipotential/quasipotential.jl
@@ -49,19 +49,67 @@ function _source_cell(
     return CartesianIndex(idx)
 end
 
+function _source_cells(
+        grid::CartesianGrid{D, T},
+        attractor::AbstractVector{<:AbstractVector},
+    ) where {D, T}
+    isempty(attractor) && throw(ArgumentError("attractor collection must not be empty"))
+    sources = CartesianIndex{D}[]
+    sizehint!(sources, length(attractor))
+    for (i, state) in pairs(attractor)
+        length(state) == D || throw(
+            DimensionMismatch(
+                "attractor state $i has length $(length(state)) but sys has D=$D",
+            ),
+        )
+        all(x -> x isa Real, state) || throw(
+            ArgumentError("attractor state $i must contain only real coordinates"),
+        )
+        push!(sources, _source_cell(grid, SVector{D, T}(state)))
+    end
+    unique!(sources)
+    return sources
+end
+
+function _olim_periodic_axes(bc, ::Val{D}) where {D}
+    bcs = _normalize_bc(bc, Val(D))
+    @inbounds for k in 1:D
+        bcs[k] isa Absorbing && throw(
+            ArgumentError(
+                "quasipotential supports Reflecting and Periodic boundaries; " *
+                    "Absorbing is a generator boundary condition and does not define " *
+                    "an OLIM boundary value",
+            ),
+        )
+    end
+    return ntuple(k -> bcs[k] isa Periodic, Val(D))
+end
+
 """
     quasipotential(sys, grid, attractor; band_radius, near_source_layers,
-                   verbose, show_progress) -> QuasiPotential{D}
+                   bc, verbose, show_progress) -> QuasiPotential{D}
 
 Compute the Freidlin-Wentzell quasipotential field `U_A(x)` from `attractor`
 using the Ordered Line Integral Method (Dahiya and Cameron 2018). The state
 dimension `D` is taken from `sys::CoupledSDEs{IIP, D, I, P}` and must match
 `grid::CartesianGrid{D}`. A warning is emitted for `D > 4`.
 
+`attractor` may be one state vector (a fixed point), or a vector of state
+vectors describing an extended attractor such as a limit cycle. Every grid
+cell touched by an extended attractor is initialised with the known value
+`U = 0`; no derivative or curvature data are used. Analytic CARE seeding is
+only available for a one-state attractor, so `near_source_layers` defaults to
+`0` for an extended attractor and must remain zero.
+
 # Keyword arguments
 * `band_radius::Int  = default_K(grid)`: accepted-band radius in grid cells.
 * `near_source_layers::Int = 3`: size of the analytic CARE seed box;
   `0` disables analytic seeding.
+* `bc = Reflecting()`: grid topology, either one boundary condition for every
+  axis or a `D`-tuple for per-axis control. [`Reflecting`](@ref) keeps the OLIM
+  stencil inside the grid; [`Periodic`](@ref) wraps neighbours and line-integral
+  geometry across the corresponding seam. [`Absorbing`](@ref) is rejected
+  because it does not specify a Hamilton-Jacobi boundary value.
 * `regularization::Real = default_regularization(grid)`: for a system with a single
   noiseless coordinate (rank-1 diffusion, e.g. momentum-only noise in a second-order
   Langevin or van der Pol oscillator) the trace-normalized diffusion is singular and
@@ -156,6 +204,7 @@ function quasipotential(
         band_radius::Int = default_K(grid),
         near_source_layers::Int = 3,
         regularization::Real = default_regularization(grid),
+        bc = Reflecting(),
         verbose::Bool = false,
         show_progress::Bool = true,
         threaded::Bool = true,
@@ -168,11 +217,42 @@ function quasipotential(
     )
     proper_FW_system(sys)
     D > 4 && @warn "quasipotential in D=$D: per-axis grid resolution will be coarse" maxlog = 1
+    periodic = _olim_periodic_axes(bc, Val(D))
     x_A = SVector{D, T}(attractor)
     return _quasipotential_impl(
         sys, grid, x_A,
         Val(band_radius), Val(near_source_layers),
-        T(regularization), verbose, show_progress, threaded, _full_rescan,
+        T(regularization), periodic, verbose, show_progress, threaded, _full_rescan,
+    )
+end
+
+function quasipotential(
+        sys::CoupledSDEs{IIP, D, I, P},
+        grid::CartesianGrid{D, T},
+        attractor::AbstractVector{<:AbstractVector};
+        band_radius::Int = default_K(grid),
+        near_source_layers::Int = 0,
+        regularization::Real = default_regularization(grid),
+        bc = Reflecting(),
+        verbose::Bool = false,
+        show_progress::Bool = true,
+        threaded::Bool = true,
+        _full_rescan::Bool = false,
+    ) where {IIP, D, I, P, T}
+    near_source_layers == 0 || throw(
+        ArgumentError(
+            "near_source_layers must be 0 for an extended attractor; " *
+                "analytic CARE seeding is only defined at a stable fixed point",
+        ),
+    )
+    proper_FW_system(sys)
+    D > 4 && @warn "quasipotential in D=$D: per-axis grid resolution will be coarse" maxlog = 1
+    sources = _source_cells(grid, attractor)
+    periodic = _olim_periodic_axes(bc, Val(D))
+    return _quasipotential_impl(
+        sys, grid, sources,
+        Val(band_radius), T(regularization), periodic,
+        verbose, show_progress, threaded, _full_rescan,
     )
 end
 
@@ -181,16 +261,41 @@ function _quasipotential_impl(
         grid::CartesianGrid{D, T},
         x_A::SVector{D, T},
         ::Val{K}, ::Val{K_seed},
-        regularization::T, verbose::Bool, show_progress::Bool, threaded::Bool,
-        full_rescan::Bool,
+        regularization::T, periodic::NTuple{D, Bool},
+        verbose::Bool, show_progress::Bool, threaded::Bool, full_rescan::Bool,
     ) where {IIP, D, I, P, T, K, K_seed}
     src = _source_cell(grid, x_A)
     L = _geometric_lagrangian(sys, T; regularization = regularization)
-    state = _OLIMState(grid, T, L.Q_inv isa SMatrix)
+    state = _OLIMState(grid, T, L.Q_inv isa SMatrix; periodic = periodic)
     _sweep!(
         state, grid, src, sys, L, Val(K), Val(K_seed);
         verbose = verbose, show_progress = show_progress, threaded = threaded,
         full_rescan = full_rescan,
     )
     return QuasiPotential{D, T}(state.U, state.back_pointer, src, grid)
+end
+
+function _quasipotential_impl(
+        sys::CoupledSDEs{IIP, D, I, P},
+        grid::CartesianGrid{D, T},
+        sources::Vector{CartesianIndex{D}},
+        ::Val{K}, regularization::T, periodic::NTuple{D, Bool},
+        verbose::Bool, show_progress::Bool, threaded::Bool, full_rescan::Bool,
+    ) where {IIP, D, I, P, T, K}
+    L = _geometric_lagrangian(sys, T; regularization = regularization)
+    state = _OLIMState(grid, T, L.Q_inv isa SMatrix; periodic = periodic)
+    @inbounds for source in sources
+        state.U[source] = zero(T)
+        state.status[source] = _ACCEPTED
+        state.back_pointer[source] = BackRef{D}(source, source, NaN32)
+    end
+    src = first(sources)
+    _sweep!(
+        state, grid, src, sys, L, Val(K), Val(0);
+        verbose = verbose, show_progress = show_progress, threaded = threaded,
+        full_rescan = full_rescan,
+    )
+    return QuasiPotential{D, T}(
+        state.U, state.back_pointer, src, grid, sources,
+    )
 end

--- a/src/largedeviations/quasipotential/quasipotential.jl
+++ b/src/largedeviations/quasipotential/quasipotential.jl
@@ -75,6 +75,77 @@ dimension `D` is taken from `sys::CoupledSDEs{IIP, D, I, P}` and must match
   (sub-Riemannian) or a non-coordinate-aligned null space are rejected.
 * `verbose::Bool      = false`
 * `show_progress::Bool = true`
+* `threaded::Bool = true`: spread each pop's local updates over the available Julia
+  threads. The result is *bitwise* identical to the serial sweep (see `_sweep_loop!`),
+  so this trades nothing for speed and is on by default; it is a no-op when Julia runs
+  with one thread. Pass `false` when `quasipotential` is itself being called from
+  inside a parallel region and you would rather own the threads yourself.
+* `_full_rescan::Bool = false`: internal. Rebuilds each candidate's value from every
+  front simplex in its stencil on every pop, instead of only from the simplexes the
+  newly popped cell just created (see `_candidate_update`). Measured 27x slower at
+  `41x41` with `K = 8` and 64x at `61x61` with `K = 12` -- the gap widens with the
+  stencil, since that is exactly the work being skipped. Present only so the tests can
+  pin the two against each other.
+
+# Accuracy
+
+The sweep minimises over a restricted set of paths (polylines through the accepted
+front), so its error is one-sided: `U` is an *upper* estimate, and `U >= 0` always.
+A cell below the exact value is a bug, not discretisation.
+
+How large that overshoot is depends almost entirely on how anisotropic the metric is:
+
+* Full-rank, well-conditioned diffusion: essentially exact. For `b = -x` with `a = I`
+  the error is `0.13%` at worst at `31` cells across and `0.03%` at `121`, with a
+  median near `10^-5`.
+* Rank-1 diffusion with `regularization = δ`: the metric has anisotropy
+  `sqrt(2/δ)`, and the error grows as `δ` shrinks. On a linear oscillator against an
+  exact CARE reference, over the inner 60% of the box (outside that the true optimal
+  path leaves the domain, which is truncation rather than method error):
+
+  | cells | `δ = 0.05` median / worst | `δ = 0.005` median / worst |
+  |-------|---------------------------|----------------------------|
+  |  61   |      5.9% / 32%           |       9.2% / 46%           |
+  | 121   |      3.6% / 18%           |       5.8% / 23%           |
+
+  i.e. falling like `O(h)`, and positive in every cell, as an upper bound must be.
+* `band_radius` past the point where the stencil already contains the cheapest path
+  changes the interior not at all: at `61` cells and `δ = 0.005`, `K = 8` through `24`
+  agree to the last bit over the inner 60%, and `K = 5` differs there by only `7e-3`.
+  What a wider stencil does buy is the *outer* region, where it keeps improving well
+  past `default_K`. So lower `band_radius` freely if you only care about the interior,
+  and raise it if you care about `U` near the domain edge.
+* Second derivatives of `U` are far less accurate than `U`. Differencing a field
+  known to `O(h)` twice leaves errors of tens of percent on a transverse Hessian even
+  where `U` itself is good to a fraction of a percent; fit `U` over a finite window
+  and account for its non-quadratic terms rather than differencing pointwise.
+
+# Performance
+
+The sweep does `O(N)` heap pops, each updating the `O(K^D)` unfinalised cells in the
+popped cell's stencil. Each such update costs `O(1)`, not `O(K^D)`: it only examines the
+simplexes the newly popped cell just created, because every other front simplex was
+already accounted for at an earlier pop (see `_candidate_update`). The work is dominated
+by evaluating `Φ`, a three-node Simpson quadrature of the Lagrangian, a few times per
+candidate simplex, so an expensive `dynamic_rule` is felt directly.
+
+In practice, for a 2D rank-1 problem:
+
+| grid  | `K`  | serial  | threaded (6 cores) |
+|-------|------|---------|--------------------|
+| 41x41 |   8  | 0.047 s |      0.035 s       |
+| 61x61 |  12  | 0.22 s  |      0.12 s        |
+| 81x81 |   9  | 0.25 s  |      0.14 s        |
+
+* Refining the grid is the main cost: `O(N)` pops times `O(K^D)` candidates, so 2x in
+  each 2D direction is about 4x, plus whatever `default_K` adds by growing like
+  `sqrt(n)`.
+* `band_radius` is much weaker than it looks. Measured cost grows like `K^1.6` at fixed
+  grid (`K = 5 -> 24` is 11x), not like the stencil volume, because most cells in a wide
+  stencil are already finalised and skipped.
+* Threading is on by default and exact; see `threaded` above. Its benefit is modest
+  (`1.3-1.9x` here) because what remains after the parallel batch -- the heap and the
+  serial apply pass -- is now a real fraction of the total.
 
 See also: [`QuasiPotential`](@ref), [`BackRef`](@ref).
 """
@@ -87,6 +158,8 @@ function quasipotential(
         regularization::Real = default_regularization(grid),
         verbose::Bool = false,
         show_progress::Bool = true,
+        threaded::Bool = true,
+        _full_rescan::Bool = false,
     ) where {IIP, D, I, P, T}
     length(attractor) == D || throw(
         DimensionMismatch(
@@ -99,7 +172,7 @@ function quasipotential(
     return _quasipotential_impl(
         sys, grid, x_A,
         Val(band_radius), Val(near_source_layers),
-        T(regularization), verbose, show_progress,
+        T(regularization), verbose, show_progress, threaded, _full_rescan,
     )
 end
 
@@ -108,14 +181,16 @@ function _quasipotential_impl(
         grid::CartesianGrid{D, T},
         x_A::SVector{D, T},
         ::Val{K}, ::Val{K_seed},
-        regularization::T, verbose::Bool, show_progress::Bool,
+        regularization::T, verbose::Bool, show_progress::Bool, threaded::Bool,
+        full_rescan::Bool,
     ) where {IIP, D, I, P, T, K, K_seed}
     src = _source_cell(grid, x_A)
     L = _geometric_lagrangian(sys, T; regularization = regularization)
     state = _OLIMState(grid, T, L.Q_inv isa SMatrix)
     _sweep!(
         state, grid, src, sys, L, Val(K), Val(K_seed);
-        verbose = verbose, show_progress = show_progress,
+        verbose = verbose, show_progress = show_progress, threaded = threaded,
+        full_rescan = full_rescan,
     )
     return QuasiPotential{D, T}(state.U, state.back_pointer, src, grid)
 end

--- a/src/largedeviations/quasipotential/state.jl
+++ b/src/largedeviations/quasipotential/state.jl
@@ -24,7 +24,8 @@ $(TYPEDEF)
 Discrete quasipotential field `U_A(x)` computed by [`quasipotential`](@ref).
 `U` is `+Inf` on cells the sweep did not reach. `back_pointer` encodes the
 winning sub-cell predecessor per cell (zeroed for the source and unreached
-cells).
+cells). `source` is the first source cell; `sources` contains every source cell
+when the attractor is supplied as a collection of states.
 
 # Fields
 $(TYPEDFIELDS)
@@ -34,6 +35,21 @@ struct QuasiPotential{D, T <: AbstractFloat}
     back_pointer::Array{BackRef{D}, D}
     source::CartesianIndex{D}
     grid::CartesianGrid{D, T}
+    sources::Vector{CartesianIndex{D}}
+end
+
+function QuasiPotential{D, T}(
+        U::Array{T, D}, back_pointer::Array{BackRef{D}, D},
+        source::CartesianIndex{D}, grid::CartesianGrid{D, T},
+    ) where {D, T <: AbstractFloat}
+    return QuasiPotential{D, T}(U, back_pointer, source, grid, [source])
+end
+
+function QuasiPotential(
+        U::Array{T, D}, back_pointer::Array{BackRef{D}, D},
+        source::CartesianIndex{D}, grid::CartesianGrid{D, T},
+    ) where {D, T <: AbstractFloat}
+    return QuasiPotential{D, T}(U, back_pointer, source, grid)
 end
 
 @enum Status::UInt8 _UNKNOWN _CONSIDERED _FRONT _ACCEPTED
@@ -46,6 +62,7 @@ struct _OLIMState{D, T, H}
     heap::H
     handles::Vector{Int}
     nbox::NTuple{D, Int}
+    periodic::NTuple{D, Bool}
     # Per-cell drift cache for the additive-noise line integral: `b_c[I] = b(c_I)`,
     # `q_c[I] = |b(c_I)|²_Q`, `sq_c[I] = |b(c_I)|_Q` at each cell center `c_I`.
     # Populated once by `_fill_node_cache!` (additive noise only). For multiplicative
@@ -59,7 +76,8 @@ end
 # `cache_drift` allocates the full-grid additive-noise drift cache; pass `false`
 # for multiplicative noise to allocate empty placeholders (see `_fill_node_cache!`).
 function _OLIMState(
-        grid::CartesianGrid{D, T}, ::Type{T}, cache_drift::Bool = true,
+        grid::CartesianGrid{D, T}, ::Type{T}, cache_drift::Bool = true;
+        periodic::NTuple{D, Bool} = ntuple(_ -> false, Val(D)),
     ) where {D, T}
     nbox = grid.nbox
     U = fill(T(Inf), nbox)
@@ -77,7 +95,7 @@ function _OLIMState(
     q_c = zeros(T, cbox)
     sq_c = zeros(T, cbox)
     return _OLIMState{D, T, typeof(heap)}(
-        U, bp, status, front, heap, handles, nbox, b_c, q_c, sq_c,
+        U, bp, status, front, heap, handles, nbox, periodic, b_c, q_c, sq_c,
     )
 end
 

--- a/src/largedeviations/quasipotential/stencil.jl
+++ b/src/largedeviations/quasipotential/stencil.jl
@@ -19,11 +19,26 @@ end
 @inline function _shift_in_bounds(
         x::CartesianIndex{D}, δ::CartesianIndex{D}, nbox::NTuple{D, Int}
     ) where {D}
-    @inbounds for d in 1:D
+    return _shift_in_bounds(x, δ, nbox, ntuple(_ -> false, Val(D)))
+end
+
+@inline function _shift_in_bounds(
+        x::CartesianIndex{D}, δ::CartesianIndex{D}, nbox::NTuple{D, Int},
+        periodic::NTuple{D, Bool},
+    ) where {D}
+    idx = ntuple(Val(D)) do d
         i = x[d] + δ[d]
-        (i < 1 || i > nbox[d]) && return nothing
+        if periodic[d]
+            mod1(i, nbox[d])
+        else
+            (i < 1 || i > nbox[d]) && return 0
+            i
+        end
     end
-    return x + δ
+    @inbounds for d in 1:D
+        idx[d] == 0 && return nothing
+    end
+    return CartesianIndex(idx)
 end
 
 @generated function _chebyshev_neighbors(::Val{D}) where {D}
@@ -40,9 +55,24 @@ end
 @inline function _is_chebyshev_adjacent(
         p::CartesianIndex{D}, q::CartesianIndex{D}
     ) where {D}
+    return _is_chebyshev_adjacent(
+        p, q, ntuple(_ -> typemax(Int), Val(D)), ntuple(_ -> false, Val(D)),
+    )
+end
+
+@inline function _wrapped_index_distance(a::Int, b::Int, n::Int, periodic::Bool)
+    δ = abs(a - b)
+    return periodic ? min(δ, n - δ) : δ
+end
+
+@inline function _is_chebyshev_adjacent(
+        p::CartesianIndex{D}, q::CartesianIndex{D},
+        nbox::NTuple{D, Int}, periodic::NTuple{D, Bool},
+    ) where {D}
     p == q && return false
     @inbounds for d in 1:D
-        abs(p[d] - q[d]) > 1 && return false
+        _wrapped_index_distance(p[d], q[d], nbox[d], periodic[d]) > 1 &&
+            return false
     end
     return true
 end
@@ -50,10 +80,39 @@ end
 @inline function _in_circular_stencil(
         x::CartesianIndex{D}, y::CartesianIndex{D}, ::Val{K}
     ) where {D, K}
+    return _in_circular_stencil(
+        x, y, Val(K), ntuple(_ -> typemax(Int), Val(D)),
+        ntuple(_ -> false, Val(D)),
+    )
+end
+
+@inline function _in_circular_stencil(
+        x::CartesianIndex{D}, y::CartesianIndex{D}, ::Val{K},
+        nbox::NTuple{D, Int}, periodic::NTuple{D, Bool},
+    ) where {D, K}
     s = 0
     @inbounds for d in 1:D
-        δ = y[d] - x[d]
+        δ = _wrapped_index_distance(y[d], x[d], nbox[d], periodic[d])
         s += δ * δ
     end
     return s != 0 && s <= K * K
+end
+
+"""
+Return the center of `I`, lifted by whole periods so it is the nearest periodic
+image to the center of `anchor`. Nonperiodic coordinates are unchanged.
+"""
+@inline function _cell_center_near(
+        grid::CartesianGrid{D, T}, I::CartesianIndex{D},
+        anchor::CartesianIndex{D}, periodic::NTuple{D, Bool},
+    ) where {D, T}
+    c = cell_center(grid, I)
+    a = cell_center(grid, anchor)
+    return SVector{D, T}(
+        ntuple(Val(D)) do d
+            periodic[d] || return c[d]
+            period = grid.h[d] * grid.nbox[d]
+            c[d] + round((a[d] - c[d]) / period) * period
+        end
+    )
 end

--- a/src/largedeviations/quasipotential/sweep.jl
+++ b/src/largedeviations/quasipotential/sweep.jl
@@ -52,16 +52,13 @@ function _seed_near_source!(
     end
 
     nbox = state.nbox
+    periodic = state.periodic
     axes_seed = ntuple(_ -> -K_seed:K_seed, Val(D))
     @inbounds for δ in CartesianIndices(axes_seed)
         iszero(δ) && continue
-        I = source + δ
-        in_bounds = true
-        for d in 1:D
-            (1 <= I[d] <= nbox[d]) || (in_bounds = false; break)
-        end
-        in_bounds || continue
-        x = cell_center(grid, I)
+        I = _shift_in_bounds(source, δ, nbox, periodic)
+        I === nothing && continue
+        x = _cell_center_near(grid, I, source, periodic)
         dx = x - x_A
         state.U[I] = dot(dx, P * dx)
         state.back_pointer[I] = BackRef{D}(source, source, NaN32)
@@ -91,6 +88,7 @@ function _sweep!(
     _seed_near_source!(state, grid, source, sys, L, Val(K_seed); verbose = verbose)
 
     nbox = state.nbox
+    periodic = state.periodic
     N = prod(nbox)
     cheb = _chebyshev_neighbors(Val(D))
 
@@ -98,7 +96,7 @@ function _sweep!(
         state.status[x] == _ACCEPTED || continue
         touches_unknown = false
         for δ in cheb
-            n = _shift_in_bounds(x, δ, nbox); n === nothing && continue
+            n = _shift_in_bounds(x, δ, nbox, periodic); n === nothing && continue
             state.status[n] == _UNKNOWN && (touches_unknown = true; break)
         end
         if touches_unknown
@@ -110,7 +108,7 @@ function _sweep!(
     @inbounds for x in CartesianIndices(state.U)
         state.status[x] == _FRONT || continue
         for δ in _stencil_offsets(Val(K), Val(D))
-            n = _shift_in_bounds(x, δ, nbox); n === nothing && continue
+            n = _shift_in_bounds(x, δ, nbox, periodic); n === nothing && continue
             state.status[n] == _UNKNOWN || continue
             Φ, br = _local_update(Val(D), n, state, grid, L, Val(K))
             isfinite(Φ) || continue
@@ -164,6 +162,7 @@ function _sweep_loop!(
         threaded::Bool = true, full_rescan::Bool = false,
     ) where {D, T, K}
     nbox = state.nbox
+    periodic = state.periodic
     cheb = _chebyshev_neighbors(Val(D))
     offsets = _stencil_offsets(Val(K), Val(D))
     cand = Vector{CartesianIndex{D}}(undef, length(offsets))
@@ -184,7 +183,7 @@ function _sweep_loop!(
 
         ncand = 0
         @inbounds for δ in offsets
-            xnew = _shift_in_bounds(c, δ, nbox); xnew === nothing && continue
+            xnew = _shift_in_bounds(c, δ, nbox, periodic); xnew === nothing && continue
             s = state.status[xnew]
             (s == _ACCEPTED || s == _FRONT) && continue
             ncand += 1
@@ -222,7 +221,7 @@ function _sweep_loop!(
 
         prune = true
         for δ in cheb
-            n = _shift_in_bounds(c, δ, nbox); n === nothing && continue
+            n = _shift_in_bounds(c, δ, nbox, periodic); n === nothing && continue
             s = state.status[n]
             if s == _UNKNOWN || s == _CONSIDERED
                 prune = false; break

--- a/src/largedeviations/quasipotential/sweep.jl
+++ b/src/largedeviations/quasipotential/sweep.jl
@@ -83,6 +83,9 @@ function _sweep!(
         L::_GeometricLagrangian{D, T},
         ::Val{K}, ::Val{K_seed};
         verbose::Bool, show_progress::Bool,
+        # Defaulted so that callers driving the sweep directly -- e.g. code that seeds
+        # `state` itself and then hands it over -- keep working unchanged.
+        threaded::Bool = true, full_rescan::Bool = false,
     ) where {D, T, K, K_seed}
     _fill_node_cache!(state, grid, L)
     _seed_near_source!(state, grid, source, sys, L, Val(K_seed); verbose = verbose)
@@ -126,23 +129,51 @@ function _sweep!(
     if show_progress
         return _sweep_loop!(
             state, grid, L, Val(K), Val(D),
-            Progress(N; desc = "OLIM sweep")
+            Progress(N; desc = "OLIM sweep"), threaded, full_rescan,
         )
     else
-        return _sweep_loop!(state, grid, L, Val(K), Val(D), nothing)
+        return _sweep_loop!(
+            state, grid, L, Val(K), Val(D), nothing, threaded, full_rescan,
+        )
     end
 end
 
 @inline _maybe_tick(::Nothing) = nothing
 @inline _maybe_tick(p::Progress) = next!(p)
 
+"""
+The local updates triggered by one pop are mutually independent, which is what makes
+the batch below safe to run in parallel.
+
+An update reads other cells only through `status[y] == _ACCEPTED`, `front[y]`, or
+`_is_final(state, y)`, i.e. only *finalised* cells (`_FRONT`/`_ACCEPTED`), whose `U`
+no longer changes. The sole non-finalised cell it touches is its own `x` (which
+`_incremental_update` seeds `best` from), and the stencil offsets are distinct so no
+two entries of a batch share an `x`. All writes happen in the apply pass afterwards,
+so no update in a batch can observe another's write.
+
+That already holds serially, which is the point: the serial loop's result is
+independent of the order in which one pop's stencil is visited. Computing the batch
+in parallel and applying the results in stencil order therefore reproduces the
+serial field *bitwise*, not merely to tolerance.
+"""
 function _sweep_loop!(
         state::_OLIMState{D, T}, grid::CartesianGrid{D, T},
         L::_GeometricLagrangian{D, T},
         ::Val{K}, ::Val{D}, prog,
+        threaded::Bool = true, full_rescan::Bool = false,
     ) where {D, T, K}
     nbox = state.nbox
     cheb = _chebyshev_neighbors(Val(D))
+    offsets = _stencil_offsets(Val(K), Val(D))
+    cand = Vector{CartesianIndex{D}}(undef, length(offsets))
+    upd = Vector{Tuple{T, BackRef{D}}}(undef, length(offsets))
+    nthr = Threads.nthreads()
+    # Below roughly two candidates per thread the spawn overhead outweighs the work,
+    # which is the regime of small grids and narrow stencils. The floor costs nothing
+    # on grids worth threading: measured at 61x61 with K=12 a pop has a median of 207
+    # candidates, and 99.8% of all candidate work sits in batches of 24 or more.
+    par_floor = threaded && nthr > 1 ? 2 * nthr : typemax(Int)
     while !isempty(state.heap)
         (_, lin_c) = pop!(state.heap)
         c = CartesianIndices(nbox)[lin_c]
@@ -151,11 +182,32 @@ function _sweep_loop!(
         state.front[c] = true
         _maybe_tick(prog)
 
-        for δ in _stencil_offsets(Val(K), Val(D))
+        ncand = 0
+        @inbounds for δ in offsets
             xnew = _shift_in_bounds(c, δ, nbox); xnew === nothing && continue
-            state.status[xnew] == _ACCEPTED && continue
-            state.status[xnew] == _FRONT    && continue
-            Φ, br = _local_update(Val(D), xnew, state, grid, L, Val(K))
+            s = state.status[xnew]
+            (s == _ACCEPTED || s == _FRONT) && continue
+            ncand += 1
+            cand[ncand] = xnew
+        end
+
+        if ncand >= par_floor
+            Threads.@threads for i in 1:ncand
+                @inbounds upd[i] = _candidate_update(
+                    Val(D), cand[i], c, state, grid, L, Val(K), full_rescan,
+                )
+            end
+        else
+            @inbounds for i in 1:ncand
+                upd[i] = _candidate_update(
+                    Val(D), cand[i], c, state, grid, L, Val(K), full_rescan,
+                )
+            end
+        end
+
+        @inbounds for i in 1:ncand
+            xnew = cand[i]
+            Φ, br = upd[i]
             (isfinite(Φ) && Φ < state.U[xnew]) || continue
             state.U[xnew] = Φ
             state.back_pointer[xnew] = br

--- a/src/largedeviations/quasipotential/update.jl
+++ b/src/largedeviations/quasipotential/update.jl
@@ -165,8 +165,9 @@ end
     ) where {D, T}
     dir = y1 - y0
     nbox = state.nbox
-    y0m = _shift_in_bounds(y0, -dir, nbox)
-    y1p = _shift_in_bounds(y1, dir, nbox)
+    periodic = state.periodic
+    y0m = _shift_in_bounds(y0, -dir, nbox, periodic)
+    y1p = _shift_in_bounds(y1, dir, nbox, periodic)
     usable(I) = I !== nothing && _is_final(state, I) && isfinite(state.U[I])
     m0 = usable(y0m) ? (state.U[y1] - state.U[y0m]) / 2 : T(NaN)
     m1 = usable(y1p) ? (state.U[y1p] - state.U[y0]) / 2 : T(NaN)
@@ -261,6 +262,7 @@ function _local_update(
         ::Val{K},
     ) where {D, T, K}
     nbox = state.nbox
+    periodic = state.periodic
     c_x = cell_center(grid, x)
     nd_x = _node_at(state, x, L)
     best = T(Inf)
@@ -270,11 +272,11 @@ function _local_update(
     # Vertex candidates from ACCEPTED-only cells (FRONT cells are handled
     # together with their edges in the simplex pass to share Φ(0) work).
     @inbounds for δ in offsets
-        y = _shift_in_bounds(x, δ, nbox); y === nothing && continue
+        y = _shift_in_bounds(x, δ, nbox, periodic); y === nothing && continue
         state.status[y] == _ACCEPTED || continue
         U_y = state.U[y]
         (isfinite(U_y) && U_y < best) || continue
-        c_y = cell_center(grid, y)
+        c_y = _cell_center_near(grid, y, x, periodic)
         Φ = _vertex_candidate(c_x, c_y, U_y, L, _node_at(state, y, L), nd_x)
         if Φ < best
             best = Φ
@@ -337,6 +339,7 @@ function _incremental_update(
         L::_GeometricLagrangian{2, T}, ::Val{K},
     ) where {T, K}
     nbox = state.nbox
+    periodic = state.periodic
     front = state.front
     @inbounds best = state.U[x]
     @inbounds best_ref = state.back_pointer[x]
@@ -344,7 +347,7 @@ function _incremental_update(
     isfinite(U_c) || return (best, best_ref)
     c_x = cell_center(grid, x)
     nd_x = _node_at(state, x, L)
-    c_c = cell_center(grid, c)
+    c_c = _cell_center_near(grid, c, x, periodic)
     nd_c = _node_at(state, c, L)
     Φc = T(NaN)
     if U_c < best
@@ -355,15 +358,15 @@ function _incremental_update(
         end
     end
     @inbounds for δ in _chebyshev_neighbors(Val(2))
-        y = _shift_in_bounds(c, δ, nbox)
+        y = _shift_in_bounds(c, δ, nbox, periodic)
         y === nothing && continue
         front[y] || continue
-        _in_circular_stencil(x, y, Val(K)) || continue
+        _in_circular_stencil(x, y, Val(K), nbox, periodic) || continue
         U_y = state.U[y]
         isfinite(U_y) || continue
         min(U_c, U_y) < best || continue
         isnan(Φc) && (Φc = U_c + _line_integral(L, c_c, c_x - c_c, nd_c, nd_x))
-        c_y = cell_center(grid, y)
+        c_y = _cell_center_near(grid, y, x, periodic)
         Φy = U_y + _line_integral(L, c_y, c_x - c_y, _node_at(state, y, L), nd_x)
         # The full scan always orients an edge from its lower linear index. Match that,
         # so the interpolant and the slope stencil are the same whichever end `c` is.
@@ -388,6 +391,7 @@ function _incremental_update(
         L::_GeometricLagrangian{3, T}, ::Val{K},
     ) where {T, K}
     nbox = state.nbox
+    periodic = state.periodic
     front = state.front
     @inbounds best = state.U[x]
     @inbounds best_ref = state.back_pointer[x]
@@ -395,7 +399,7 @@ function _incremental_update(
     isfinite(U_c) || return (best, best_ref)
     c_x = cell_center(grid, x)
     nd_x = _node_at(state, x, L)
-    c_c = cell_center(grid, c)
+    c_c = _cell_center_near(grid, c, x, periodic)
     Φc = U_c + _line_integral(L, c_c, c_x - c_c, _node_at(state, c, L), nd_x)
     if Φc < best
         best = Φc
@@ -406,24 +410,26 @@ function _incremental_update(
     # other two, so the triangles containing `c` are exactly the mutually adjacent
     # front pairs drawn from `c`'s own neighbourhood.
     @inbounds for δ1 in cheb
-        p = _shift_in_bounds(c, δ1, nbox)
+        p = _shift_in_bounds(c, δ1, nbox, periodic)
         p === nothing && continue
         front[p] || continue
-        _in_circular_stencil(x, p, Val(K)) || continue
+        _in_circular_stencil(x, p, Val(K), nbox, periodic) || continue
         isfinite(state.U[p]) || continue
         for δ2 in cheb
-            q = _shift_in_bounds(c, δ2, nbox)
+            q = _shift_in_bounds(c, δ2, nbox, periodic)
             q === nothing && continue
             q > p || continue
             front[q] || continue
-            _is_chebyshev_adjacent(p, q) || continue
-            _in_circular_stencil(x, q, Val(K)) || continue
+            _is_chebyshev_adjacent(p, q, nbox, periodic) || continue
+            _in_circular_stencil(x, q, Val(K), nbox, periodic) || continue
             isfinite(state.U[q]) || continue
             # Sort the corners so the barycentric frame matches the full scan's, which
             # always bases a triangle at its lowest-index corner.
             a, b, d = _sorted3(c, p, q)
             Φ, λ1, _ = _triangle_minimum(
-                c_x, cell_center(grid, a), cell_center(grid, b), cell_center(grid, d),
+                c_x, _cell_center_near(grid, a, x, periodic),
+                _cell_center_near(grid, b, x, periodic),
+                _cell_center_near(grid, d, x, periodic),
                 state.U[a], state.U[b], state.U[d], L, nd_x,
             )
             if Φ < best
@@ -451,17 +457,18 @@ function _add_simplex_candidates(
         ::Val{K}, ::Val{2},
     ) where {T, K}
     nbox = state.nbox
+    periodic = state.periodic
     front = state.front
     nd_x = _node_at(state, x, L)
     offsets = _stencil_offsets(Val(K), Val(2))
     cheb = _chebyshev_neighbors(Val(2))
     @inbounds for δ0 in offsets
-        y0 = _shift_in_bounds(x, δ0, nbox)
+        y0 = _shift_in_bounds(x, δ0, nbox, periodic)
         y0 === nothing && continue
         front[y0] || continue
         U0 = state.U[y0]
         isfinite(U0) || continue
-        c_y0 = cell_center(grid, y0)
+        c_y0 = _cell_center_near(grid, y0, x, periodic)
         nd_y0 = _node_at(state, y0, L)
         # Φ0 = vertex candidate from y0 (same as edge Φ(λ=0)). Computed at most once
         # per y0, then reused for the vertex update and as the Φ(0) endpoint of every
@@ -475,11 +482,11 @@ function _add_simplex_candidates(
             end
         end
         for δch in cheb
-            y1 = _shift_in_bounds(y0, δch, nbox)
+            y1 = _shift_in_bounds(y0, δch, nbox, periodic)
             y1 === nothing && continue
             y1 > y0 || continue
             front[y1] || continue
-            _in_circular_stencil(x, y1, Val(K)) || continue
+            _in_circular_stencil(x, y1, Val(K), nbox, periodic) || continue
             U1 = state.U[y1]
             isfinite(U1) || continue
             # The limited interpolant keeps the edge value in [min(U0, U1), max(U0, U1)]
@@ -489,7 +496,7 @@ function _add_simplex_candidates(
             # endpoint those candidates were lost outright.
             min(U0, U1) < best || continue
             isnan(Φ0) && (Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0, nd_y0, nd_x))
-            c_y1 = cell_center(grid, y1)
+            c_y1 = _cell_center_near(grid, y1, x, periodic)
             # Φ(1) is the vertex candidate from y1, reused as the edge's λ=1 endpoint.
             Φ1 = U1 + _line_integral(L, c_y1, c_x - c_y1, _node_at(state, y1, L), nd_x)
             m0, m1 = _edge_slope_estimates(state, y0, y1)
@@ -514,41 +521,42 @@ function _add_simplex_candidates(
         ::Val{K}, ::Val{3},
     ) where {T, K}
     nbox = state.nbox
+    periodic = state.periodic
     front = state.front
     nd_x = _node_at(state, x, L)
     offsets = _stencil_offsets(Val(K), Val(3))
     cheb = _chebyshev_neighbors(Val(3))
     @inbounds for δ0 in offsets
-        y0 = _shift_in_bounds(x, δ0, nbox)
+        y0 = _shift_in_bounds(x, δ0, nbox, periodic)
         y0 === nothing && continue
         front[y0] || continue
         U0 = state.U[y0]
         isfinite(U0) || continue
-        c_y0 = cell_center(grid, y0)
+        c_y0 = _cell_center_near(grid, y0, x, periodic)
         Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0, _node_at(state, y0, L), nd_x)
         if Φ0 < best
             best = Φ0
             best_ref = BackRef{3}(y0, y0, NaN32)
         end
         for δch1 in cheb
-            y1 = _shift_in_bounds(y0, δch1, nbox)
+            y1 = _shift_in_bounds(y0, δch1, nbox, periodic)
             y1 === nothing && continue
             y1 > y0 || continue
             front[y1] || continue
-            _in_circular_stencil(x, y1, Val(K)) || continue
+            _in_circular_stencil(x, y1, Val(K), nbox, periodic) || continue
             U1 = state.U[y1]
             isfinite(U1) || continue
-            c_y1 = cell_center(grid, y1)
+            c_y1 = _cell_center_near(grid, y1, x, periodic)
             for δch2 in cheb
-                y2 = _shift_in_bounds(y0, δch2, nbox)
+                y2 = _shift_in_bounds(y0, δch2, nbox, periodic)
                 y2 === nothing && continue
                 y2 > y1 || continue
                 front[y2] || continue
-                _is_chebyshev_adjacent(y1, y2) || continue
-                _in_circular_stencil(x, y2, Val(K)) || continue
+                _is_chebyshev_adjacent(y1, y2, nbox, periodic) || continue
+                _in_circular_stencil(x, y2, Val(K), nbox, periodic) || continue
                 U2 = state.U[y2]
                 isfinite(U2) || continue
-                c_y2 = cell_center(grid, y2)
+                c_y2 = _cell_center_near(grid, y2, x, periodic)
                 Φ, λ1, _ = _triangle_minimum(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, nd_x)
                 if Φ < best
                     best = Φ

--- a/src/largedeviations/quasipotential/update.jl
+++ b/src/largedeviations/quasipotential/update.jl
@@ -39,28 +39,49 @@ end
 
 # The interior point `y` is interpolated (never a cell center), so the s=0 node is
 # always live; only the shared s=1 node `c_x` is cached via `nd_x`.
+#
+# `s0`/`s1` are *prepared* slopes (secant-substituted and limited by
+# `_prepare_slopes`). They do not depend on `λ`, so the caller hoists that work out
+# of the many evaluations made along a single edge.
 @inline function _edge_phi(
         c_x::SVector{D, T}, c_y0::SVector{D, T}, c_y1::SVector{D, T},
-        U0::T, U1::T, m0::T, m1::T, λ::T,
+        U0::T, U1::T, s0::T, s1::T, λ::T,
         L::_GeometricLagrangian{D, T}, nd_x,
     ) where {D, T}
     y = (one(T) - λ) * c_y0 + λ * c_y1
-    return _hermite_U(U0, U1, m0, m1, λ) + _line_integral(L, y, c_x - y, nothing, nd_x)
+    return _hermite_prepared(U0, U1, s0, s1, λ) +
+        _line_integral(L, y, c_x - y, nothing, nd_x)
 end
 
 @inline function _edge_dphi(
         c_x::SVector{D, T}, c_y0::SVector{D, T}, c_y1::SVector{D, T},
-        U0::T, U1::T, m0::T, m1::T, λ::T,
+        U0::T, U1::T, s0::T, s1::T, λ::T,
         L::_GeometricLagrangian{D, T}, nd_x,
     ) where {D, T}
     h = sqrt(eps(T))
     λp = clamp(λ + h, zero(T), one(T))
     λm = clamp(λ - h, zero(T), one(T))
     return (
-        _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λp, L, nd_x) -
-            _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λm, L, nd_x)
+        _edge_phi(c_x, c_y0, c_y1, U0, U1, s0, s1, λp, L, nd_x) -
+            _edge_phi(c_x, c_y0, c_y1, U0, U1, s0, s1, λm, L, nd_x)
     ) / (λp - λm)
 end
+
+"""
+Convergence tolerance on the edge parameter `λ` for the interior root find, and the
+main lever on how often `Φ` is evaluated: `itp_root` takes on the order of
+`log2(1 / (2 * _EDGE_ATOL))` iterations at two `Φ` evaluations each.
+
+It can afford to be loose, because `Φ` is stationary at `λ*`: mislocating the minimiser
+by `ε` perturbs `U` only by `Φ'' ε^2 / 2`, and erring high is the safe direction for an
+upper-bound method. Loosening it does *not* risk missing the narrow interior valley an
+anisotropic metric produces -- a bracketed root find converges to the root of `dΦ/dλ`
+whatever the tolerance, and only its precision changes. Measured on a rank-1 oscillator
+at `61x61`, going from `1e-4` to `1e-2` moved the median error in `U` by 0.02 percentage
+points, so this is not where the accuracy lives; it is kept tight because since
+`_candidate_update` went incremental the root find is no longer the bottleneck either.
+"""
+const _EDGE_ATOL = 1.0e-4
 
 """
 Edge candidate minimum (§4.4). Evaluates Φ(0), Φ(1), and an ITP root of
@@ -72,37 +93,70 @@ struct _EdgeDPhi{D, T, LT, NX}
     c_y1::SVector{D, T}
     U0::T
     U1::T
-    m0::T
-    m1::T
+    s0::T
+    s1::T
     L::LT
     nd_x::NX
 end
 @inline (g::_EdgeDPhi)(λ) =
-    _edge_dphi(g.c_x, g.c_y0, g.c_y1, g.U0, g.U1, g.m0, g.m1, λ, g.L, g.nd_x)
+    _edge_dphi(g.c_x, g.c_y0, g.c_y1, g.U0, g.U1, g.s0, g.s1, λ, g.L, g.nd_x)
 
+# `Φ0`/`Φ1` are the edge's λ=0 and λ=1 values. They coincide with the *vertex*
+# candidates from `c_y0` and `c_y1`, which every caller has already computed, so they
+# are required rather than defaulted -- recomputing them here would double the cheap
+# part of the edge and hide it behind a default argument.
 @inline function _edge_minimum(
         c_x::SVector{D, T},
         c_y0::SVector{D, T}, c_y1::SVector{D, T},
         U0::T, U1::T, m0::T, m1::T,
-        L::_GeometricLagrangian{D, T}, nd_x,
-        cutoff::T = T(Inf),
-        Φ0::T = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, zero(T), L, nd_x),
-        Φ1::T = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, one(T), L, nd_x),
+        L::_GeometricLagrangian{D, T}, nd_x, Φ0::T, Φ1::T,
     ) where {D, T}
+    s0, s1 = _prepare_slopes(U0, U1, m0, m1)
     best, λstar = (Φ0 <= Φ1) ? (Φ0, zero(T)) : (Φ1, one(T))
-    # Skip ITP if both endpoints already exceed the caller's running best.
-    # The interior could still be lower, but on Maupertuis-like problems the
-    # interior minimum is bracketed by smaller endpoints in practice.
-    (Φ0 > cutoff && Φ1 > cutoff) && return (best, λstar)
-    g = _EdgeDPhi(c_x, c_y0, c_y1, U0, U1, m0, m1, L, nd_x)
-    λroot, ok = itp_root(g, zero(T), one(T); atol = T(1.0e-4), maxiter = 20)
+    # The interior root is always sought. It used to be skipped when both endpoints
+    # exceeded the caller's running best, on the assumption that the interior minimum
+    # is bracketed by smaller endpoints; it is not. Under an anisotropic metric Φ(λ)
+    # has a narrow interior valley (the foot point where the segment aligns with the
+    # drift), so the endpoints are a poor proxy and the only sound bound available,
+    # Φ ≥ min(U0, U1), is far too weak to prune on. Skipping cost up to a factor 1.8
+    # in worst-case accuracy and made the answer depend on cell visit order.
+    #
+    # Entering the root find used to cost four Φ evaluations: `itp_root` opens with
+    # `f(0)` and `f(1)`, and `f = _edge_dphi` is a two-point difference. But
+    # `_edge_dphi` clamps its stencil at the boundary, so its endpoint values are
+    # *one-sided* differences whose far node is Φ(0) resp. Φ(1) -- both already in
+    # hand. Building them here costs two Φ evaluations instead of four and is
+    # bitwise identical (the clamped denominators are exactly `h`).
+    h = sqrt(eps(T))
+    λ1m = one(T) - h
+    dΦ0 = (_edge_phi(c_x, c_y0, c_y1, U0, U1, s0, s1, h, L, nd_x) - Φ0) / h
+    dΦ1 = (Φ1 - _edge_phi(c_x, c_y0, c_y1, U0, U1, s0, s1, λ1m, L, nd_x)) / (one(T) - λ1m)
+    # Only a bracketed sign change can yield an interior minimiser. Without one
+    # `itp_root` either reports `ok = false` or returns an endpoint, and an endpoint
+    # `λroot` fails the `0 < λroot < 1` test below -- so this gate skips exactly the
+    # calls whose result is discarded, and skips them before the setup cost.
+    dΦ0 * dΦ1 < zero(T) || return (best, λstar)
+    g = _EdgeDPhi(c_x, c_y0, c_y1, U0, U1, s0, s1, L, nd_x)
+    λroot, ok = itp_root(
+        g, zero(T), one(T); atol = T(_EDGE_ATOL), maxiter = 20, fa = dΦ0, fb = dΦ1,
+    )
     if ok && zero(T) < λroot < one(T)
-        Φi = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λroot, L, nd_x)
+        Φi = _edge_phi(c_x, c_y0, c_y1, U0, U1, s0, s1, λroot, L, nd_x)
         if Φi < best
             best, λstar = Φi, λroot
         end
     end
     return (best, λstar)
+end
+
+# A cell's `U` is final once it has been popped from the heap (`_FRONT`) or pruned
+# (`_ACCEPTED`). A `_CONSIDERED` cell still holds a tentative upper bound that later
+# updates can only lower, so a divided difference taken against it is biased high --
+# and a slope that is too large is exactly what drives the Hermite interpolant below
+# both edge endpoints. `_UNKNOWN` cells hold `Inf` and are excluded by `isfinite`.
+@inline function _is_final(state::_OLIMState{D}, I::CartesianIndex{D}) where {D}
+    @inbounds s = state.status[I]
+    return s == _FRONT || s == _ACCEPTED
 end
 
 @inline function _edge_slope_estimates(
@@ -113,10 +167,9 @@ end
     nbox = state.nbox
     y0m = _shift_in_bounds(y0, -dir, nbox)
     y1p = _shift_in_bounds(y1, dir, nbox)
-    m0 = (y0m !== nothing && isfinite(state.U[y0m])) ?
-        (state.U[y1] - state.U[y0m]) / 2 : T(NaN)
-    m1 = (y1p !== nothing && isfinite(state.U[y1p])) ?
-        (state.U[y1p] - state.U[y0]) / 2 : T(NaN)
+    usable(I) = I !== nothing && _is_final(state, I) && isfinite(state.U[I])
+    m0 = usable(y0m) ? (state.U[y1] - state.U[y0m]) / 2 : T(NaN)
+    m1 = usable(y1p) ? (state.U[y1p] - state.U[y0]) / 2 : T(NaN)
     return (m0, m1)
 end
 
@@ -148,15 +201,23 @@ end
     Φ2 = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, zero(T), one(T), nd_x)
     Φ2 < best && ((best, bλ1, bλ2) = (Φ2, zero(T), one(T)))
 
-    Φe01, λs01 = _edge_minimum(c_x, c_y0, c_y1, U0, U1, T(NaN), T(NaN), L, nd_x)
+    # The three barycentric corners are exactly the edges' λ=0 / λ=1 values, so
+    # Φ00/Φ1/Φ2 above serve as the endpoint values for all three edges.
+    Φe01, λs01 = _edge_minimum(
+        c_x, c_y0, c_y1, U0, U1, T(NaN), T(NaN), L, nd_x, Φ00, Φ1,
+    )
     if Φe01 < best
         best = Φe01; bλ1 = λs01; bλ2 = zero(T)
     end
-    Φe02, λs02 = _edge_minimum(c_x, c_y0, c_y2, U0, U2, T(NaN), T(NaN), L, nd_x)
+    Φe02, λs02 = _edge_minimum(
+        c_x, c_y0, c_y2, U0, U2, T(NaN), T(NaN), L, nd_x, Φ00, Φ2,
+    )
     if Φe02 < best
         best = Φe02; bλ1 = zero(T); bλ2 = λs02
     end
-    Φe12, λs12 = _edge_minimum(c_x, c_y1, c_y2, U1, U2, T(NaN), T(NaN), L, nd_x)
+    Φe12, λs12 = _edge_minimum(
+        c_x, c_y1, c_y2, U1, U2, T(NaN), T(NaN), L, nd_x, Φ1, Φ2,
+    )
     if Φe12 < best
         best = Φe12; bλ1 = one(T) - λs12; bλ2 = λs12
     end
@@ -230,6 +291,157 @@ end
     best, best_ref, x, c_x, state, grid, L, ::Val{K}, ::Val{D},
 ) where {K, D} = (best, best_ref)
 
+"""
+Update `x` in response to a single cell `c` having just been popped.
+
+Popping `c` is the only status change, so the only candidates `x` has not already been
+offered are the ones built from `c`: the vertex `c` itself and the simplexes having `c`
+as a corner. Every other front simplex was already complete at an earlier pop -- the
+stencil relation `|x - y| <= K` is symmetric, so when a simplex's last corner `y` was
+popped, `x` lay in `y`'s stencil exactly when `y` lies in `x`'s, and `x` was updated
+then. `state.U[x]` therefore already holds the minimum over all of them, and this starts
+from that value instead of rebuilding it.
+
+That turns the per-pop cost for a cell from "every front simplex in the `K`-disc"
+(hundreds of edges at the radii an anisotropic metric needs) into "the at most eight
+edges touching `c`", which is where nearly all of the sweep's time was going.
+
+The one thing the full rescan did additionally was re-evaluate old edges whose slope
+estimates had since improved, as more neighbours became final. Skipping that can only
+leave `U` higher, never lower, so the sweep stays the upper bound it is documented to be.
+The price is small: on a rank-1 oscillator at `61x61` with `K = 12`, against an exact CARE
+reference, the median error goes from 9.07% to 9.20% and the worst case is unchanged at
+46%, with `U` raised rather than lowered in 99.9% of cells. `_full_rescan = true` on
+`quasipotential` restores the old behaviour, and the tests hold the two side by side.
+"""
+@inline _candidate_update(
+    v::Val{D}, x, _c, state, grid, L, vk, _full,
+) where {D} = _local_update(v, x, state, grid, L, vk)
+
+# Only `D = 2` and `D = 3` may take the incremental path. For every other `D` the
+# simplex pass is a no-op, so candidates come solely from the `_ACCEPTED` vertex loop,
+# and a cell joins that set by being *pruned* (`_FRONT -> _ACCEPTED`) -- an event that
+# triggers no update and so cannot be caught incrementally.
+for VD in (:(Val{2}), :(Val{3}))
+    @eval @inline function _candidate_update(v::$VD, x, c, state, grid, L, vk, full)
+        # A cell seen for the first time has no accumulated value to build on.
+        @inbounds (full || state.status[x] == _UNKNOWN) &&
+            return _local_update(v, x, state, grid, L, vk)
+        return _incremental_update(v, x, c, state, grid, L, vk)
+    end
+end
+
+function _incremental_update(
+        ::Val{2}, x::CartesianIndex{2}, c::CartesianIndex{2},
+        state::_OLIMState{2, T}, grid::CartesianGrid{2, T},
+        L::_GeometricLagrangian{2, T}, ::Val{K},
+    ) where {T, K}
+    nbox = state.nbox
+    front = state.front
+    @inbounds best = state.U[x]
+    @inbounds best_ref = state.back_pointer[x]
+    @inbounds U_c = state.U[c]
+    isfinite(U_c) || return (best, best_ref)
+    c_x = cell_center(grid, x)
+    nd_x = _node_at(state, x, L)
+    c_c = cell_center(grid, c)
+    nd_c = _node_at(state, c, L)
+    Φc = T(NaN)
+    if U_c < best
+        Φc = U_c + _line_integral(L, c_c, c_x - c_c, nd_c, nd_x)
+        if Φc < best
+            best = Φc
+            best_ref = BackRef{2}(c, c, NaN32)
+        end
+    end
+    @inbounds for δ in _chebyshev_neighbors(Val(2))
+        y = _shift_in_bounds(c, δ, nbox)
+        y === nothing && continue
+        front[y] || continue
+        _in_circular_stencil(x, y, Val(K)) || continue
+        U_y = state.U[y]
+        isfinite(U_y) || continue
+        min(U_c, U_y) < best || continue
+        isnan(Φc) && (Φc = U_c + _line_integral(L, c_c, c_x - c_c, nd_c, nd_x))
+        c_y = cell_center(grid, y)
+        Φy = U_y + _line_integral(L, c_y, c_x - c_y, _node_at(state, y, L), nd_x)
+        # The full scan always orients an edge from its lower linear index. Match that,
+        # so the interpolant and the slope stencil are the same whichever end `c` is.
+        lo = c < y
+        y0, y1 = lo ? (c, y) : (y, c)
+        cy0, cy1 = lo ? (c_c, c_y) : (c_y, c_c)
+        U0, U1 = lo ? (U_c, U_y) : (U_y, U_c)
+        Φ0, Φ1 = lo ? (Φc, Φy) : (Φy, Φc)
+        m0, m1 = _edge_slope_estimates(state, y0, y1)
+        Φ, λstar = _edge_minimum(c_x, cy0, cy1, U0, U1, m0, m1, L, nd_x, Φ0, Φ1)
+        if Φ < best
+            best = Φ
+            best_ref = BackRef{2}(y0, y1, Float32(λstar))
+        end
+    end
+    return (best, best_ref)
+end
+
+function _incremental_update(
+        ::Val{3}, x::CartesianIndex{3}, c::CartesianIndex{3},
+        state::_OLIMState{3, T}, grid::CartesianGrid{3, T},
+        L::_GeometricLagrangian{3, T}, ::Val{K},
+    ) where {T, K}
+    nbox = state.nbox
+    front = state.front
+    @inbounds best = state.U[x]
+    @inbounds best_ref = state.back_pointer[x]
+    @inbounds U_c = state.U[c]
+    isfinite(U_c) || return (best, best_ref)
+    c_x = cell_center(grid, x)
+    nd_x = _node_at(state, x, L)
+    c_c = cell_center(grid, c)
+    Φc = U_c + _line_integral(L, c_c, c_x - c_c, _node_at(state, c, L), nd_x)
+    if Φc < best
+        best = Φc
+        best_ref = BackRef{3}(c, c, NaN32)
+    end
+    cheb = _chebyshev_neighbors(Val(3))
+    # Every corner of a triangle the full scan enumerates is Chebyshev-adjacent to the
+    # other two, so the triangles containing `c` are exactly the mutually adjacent
+    # front pairs drawn from `c`'s own neighbourhood.
+    @inbounds for δ1 in cheb
+        p = _shift_in_bounds(c, δ1, nbox)
+        p === nothing && continue
+        front[p] || continue
+        _in_circular_stencil(x, p, Val(K)) || continue
+        isfinite(state.U[p]) || continue
+        for δ2 in cheb
+            q = _shift_in_bounds(c, δ2, nbox)
+            q === nothing && continue
+            q > p || continue
+            front[q] || continue
+            _is_chebyshev_adjacent(p, q) || continue
+            _in_circular_stencil(x, q, Val(K)) || continue
+            isfinite(state.U[q]) || continue
+            # Sort the corners so the barycentric frame matches the full scan's, which
+            # always bases a triangle at its lowest-index corner.
+            a, b, d = _sorted3(c, p, q)
+            Φ, λ1, _ = _triangle_minimum(
+                c_x, cell_center(grid, a), cell_center(grid, b), cell_center(grid, d),
+                state.U[a], state.U[b], state.U[d], L, nd_x,
+            )
+            if Φ < best
+                best = Φ
+                best_ref = BackRef{3}(a, b, Float32(λ1))
+            end
+        end
+    end
+    return (best, best_ref)
+end
+
+@inline function _sorted3(p::T, q::T, r::T) where {T}
+    lo, hi = q < r ? (q, r) : (r, q)
+    p < lo && return (p, lo, hi)
+    p < hi && return (lo, p, hi)
+    return (lo, hi, p)
+end
+
 function _add_simplex_candidates(
         best, best_ref, x::CartesianIndex{2},
         c_x::SVector{2, T},
@@ -249,16 +461,18 @@ function _add_simplex_candidates(
         front[y0] || continue
         U0 = state.U[y0]
         isfinite(U0) || continue
-        U0 < best || continue  # vertex bound Φ ≥ U0
         c_y0 = cell_center(grid, y0)
         nd_y0 = _node_at(state, y0, L)
-        # Φ0 = vertex candidate from y0 (same as edge Φ(λ=0)). Compute once,
-        # reuse for the vertex update and as the Φ(0) endpoint of every edge
-        # leaving y0.
-        Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0, nd_y0, nd_x)
-        if Φ0 < best
-            best = Φ0
-            best_ref = BackRef{2}(y0, y0, NaN32)
+        # Φ0 = vertex candidate from y0 (same as edge Φ(λ=0)). Computed at most once
+        # per y0, then reused for the vertex update and as the Φ(0) endpoint of every
+        # edge leaving y0. Deferred because `U0 ≥ best` bounds Φ0 out on its own.
+        Φ0 = T(NaN)
+        if U0 < best
+            Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0, nd_y0, nd_x)
+            if Φ0 < best
+                best = Φ0
+                best_ref = BackRef{2}(y0, y0, NaN32)
+            end
         end
         for δch in cheb
             y1 = _shift_in_bounds(y0, δch, nbox)
@@ -267,14 +481,20 @@ function _add_simplex_candidates(
             front[y1] || continue
             _in_circular_stencil(x, y1, Val(K)) || continue
             U1 = state.U[y1]
-            (isfinite(U1) && U1 < best) || continue
+            isfinite(U1) || continue
+            # The limited interpolant keeps the edge value in [min(U0, U1), max(U0, U1)]
+            # and the line integral is nonnegative, so Φ ≥ min(U0, U1). Requiring *both*
+            # endpoints below `best` (as this once did) discards edges whose cheaper end
+            # can still win, and since each edge is visited only from its lower-index
+            # endpoint those candidates were lost outright.
+            min(U0, U1) < best || continue
+            isnan(Φ0) && (Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0, nd_y0, nd_x))
             c_y1 = cell_center(grid, y1)
-            # Φ(1) is the vertex candidate from y1; cheap, gates ITP.
+            # Φ(1) is the vertex candidate from y1, reused as the edge's λ=1 endpoint.
             Φ1 = U1 + _line_integral(L, c_y1, c_x - c_y1, _node_at(state, y1, L), nd_x)
-            (min(Φ0, Φ1) < best) || continue
             m0, m1 = _edge_slope_estimates(state, y0, y1)
             Φ, λstar = _edge_minimum(
-                c_x, c_y0, c_y1, U0, U1, m0, m1, L, nd_x, best, Φ0, Φ1,
+                c_x, c_y0, c_y1, U0, U1, m0, m1, L, nd_x, Φ0, Φ1,
             )
             if Φ < best
                 best = Φ

--- a/test/largedeviations/quasipotential.jl
+++ b/test/largedeviations/quasipotential.jl
@@ -2,6 +2,7 @@ using CriticalTransitions
 using CriticalTransitions: cell_center
 
 using LinearAlgebra
+using Statistics: median
 using Test
 
 const CT_ = CriticalTransitions
@@ -17,6 +18,18 @@ const CT_ = CriticalTransitions
 
         rf, _ = CT_.itp_root(x -> x - 0.25f0, 0.0f0, 1.0f0)
         @test isapprox(rf, 0.25f0; atol = 1.0f-5)
+
+        # Passing the endpoint values in must give the identical root while calling `f`
+        # two fewer times: that is what lets `_edge_minimum` reuse Φ(0) and Φ(1).
+        f = x -> (x - 0.37) * (x + 0.4)
+        ncall = Ref(0)
+        counted = x -> (ncall[] += 1; f(x))
+        rp, okp = CT_.itp_root(counted, 0.0, 1.0; fa = f(0.0), fb = f(1.0))
+        withkw = ncall[]
+        ncall[] = 0
+        rn, okn = CT_.itp_root(counted, 0.0, 1.0)
+        @test (rp, okp) === (rn, okn)
+        @test withkw == ncall[] - 2
     end
 
     @testset "GeometricLagrangian" begin
@@ -52,6 +65,27 @@ const CT_ = CriticalTransitions
         )
         # NaN slopes fall back to the secant (U1 - U0), reducing to linear interpolation.
         @test isapprox(CT_._hermite_U(0.0, 1.0, NaN, NaN, 0.5), 0.5; atol = 1.0e-12)
+    end
+
+    @testset "hermite_U slope limiting" begin
+        # The limiter must not perturb data that is already monotone-compatible:
+        # secant slopes (the NaN fallback) and zero slopes are inside [0, 3Δ].
+        @test CT_._limit_slopes(0.0, 1.0, 1.0, 1.0) == (1.0, 1.0)
+        @test CT_._limit_slopes(0.0, 1.0, 0.0, 0.0) == (0.0, 0.0)
+        @test CT_._limit_slopes(1.0, 0.0, -1.0, -1.0) == (-1.0, -1.0)
+        # Slopes that fight the secant are zeroed; oversteep ones are capped at 3Δ.
+        @test CT_._limit_slopes(0.0, 1.0, -5.0, 9.0) == (0.0, 3.0)
+        @test CT_._limit_slopes(0.0, 0.0, -1.0, 1.0) == (0.0, 0.0)
+
+        # Regression: unlimited, U0 = U1 = 0 with m0 = -a, m1 = a gives
+        # H(λ) = -a λ(1 - λ), i.e. -a/4 at the midpoint. Adding a nonnegative line
+        # integral to a negative interpolated value is the only route by which the
+        # sweep can return U < 0, so the interpolant must stay in [min(U0,U1), max].
+        for λ in (0.1, 0.25, 0.5, 0.75, 0.9)
+            @test CT_._hermite_U(0.0, 0.0, -1.0, 1.0, λ) == 0.0
+            H = CT_._hermite_U(0.3, 0.7, -4.0, 9.0, λ)
+            @test 0.3 - 1.0e-14 <= H <= 0.7 + 1.0e-14
+        end
     end
 
     @testset "stencil_offsets" begin
@@ -336,7 +370,162 @@ const CT_ = CriticalTransitions
         isad = argmin(abs.(xs)); jsad = argmin(abs.(ps))
         @test abs(qp.U[isad, jsad] - 0.25) <= 0.02               # saddle barrier
         @test qp.U[qp.source] == 0.0
-        @test all(>=(-1.0e-8), filter(isfinite, qp.U))
+        @test all(>=(0), filter(isfinite, qp.U))   # exactly 0, not -1e-8
+    end
+
+    @testset "rank-1 linear oscillator: U >= 0 and exact CARE reference" begin
+        # Linear drift plus constant diffusion has a globally quadratic quasipotential
+        # U(x) = x' P x, with P the CARE solution for the *regularized* metric that OLIM
+        # actually solves with. That makes this the sharpest available end-to-end check.
+        #
+        # Regression: at reg = 0.005 (metric anisotropy sqrt(2/reg) = 20) the unlimited
+        # Hermite edge interpolant undershot badly -- min U = -0.218 with 123 cells below
+        # zero, and U up to 78% *below* the exact value. U ≥ 0 holds by definition and
+        # OLIM minimises over a restricted set of paths, so its error must be one-sided
+        # (an overshoot); a negative cell or an undershoot is a bug, not discretisation.
+        gam = 0.5
+        drift(u, p, t) = SVector(u[2], -u[1] - gam * u[2])
+        gmat(u, p, t) = @SMatrix [0.0 0.0; 0.0 1.0]
+        sys = CoupledSDEs(
+            drift, SA[0.0, 0.0]; g = gmat,
+            noise_prototype = SMatrix{2, 2}(zeros(2, 2)),
+        )
+        reg = 0.005
+        P = CT_._care([0.0 1.0; -1.0 -gam], [reg 0.0; 0.0 2.0])
+        grid = CartesianGrid((-1.5, 1.5, 25), (-1.5, 1.5, 25))
+        qp = quasipotential(
+            sys, grid, [0.0, 0.0];
+            band_radius = 12, regularization = reg, show_progress = false,
+        )
+        @test all(>=(0), filter(isfinite, qp.U))
+        @test qp.U[qp.source] == 0.0
+        # Away from the boundary, where the optimal path is not truncated by the box.
+        rel = Float64[]
+        for I in CartesianIndices(qp.U)
+            isfinite(qp.U[I]) || continue
+            x = cell_center(grid, I)
+            (abs(x[1]) <= 0.9 && abs(x[2]) <= 0.9) || continue
+            ue = dot(x, P * x)
+            ue > 0.05 && push!(rel, (qp.U[I] - ue) / ue)
+        end
+        @test minimum(rel) > -0.02                 # was -0.78
+        @test median(rel) < 0.1                    # was -0.18 (undershoot)
+    end
+
+    @testset "sweep is independent of cell visit order (equivariance)" begin
+        # b(u) = (p, -x - γp) is odd and the grid is symmetric about the origin with an
+        # odd cell count, so the reflection (x, p) -> (-x, -p) maps cell (i, j) onto
+        # (n+1-i, n+1-j) and U must be equivariant. It only can be if every candidate
+        # gate is a sound bound: a gate that prunes against the *running* best makes the
+        # accepted value depend on the order cells come off the heap, which is not
+        # symmetric. This caught pruning that left a 7% asymmetry in a fitted transverse
+        # curvature (and up to 8% directly in U) where round-off is the only floor.
+        gam = 0.5
+        drift(u, p, t) = SVector(u[2], -u[1] - gam * u[2])
+        gmat(u, p, t) = @SMatrix [0.0 0.0; 0.0 1.0]
+        sys = CoupledSDEs(
+            drift, SA[0.0, 0.0]; g = gmat,
+            noise_prototype = SMatrix{2, 2}(zeros(2, 2)),
+        )
+        n = 61
+        grid = CartesianGrid((-1.5, 1.5, n), (-1.5, 1.5, n))
+        qp = quasipotential(
+            sys, grid, [0.0, 0.0];
+            band_radius = 8, regularization = 0.05, show_progress = false,
+        )
+        U = qp.U
+        scale = maximum(filter(isfinite, U))
+        gaps = Float64[]
+        for i in 1:n, j in 1:n
+            a, b = U[i, j], U[n + 1 - i, n + 1 - j]
+            (isfinite(a) && isfinite(b)) || continue
+            m = max(abs(a), abs(b))
+            m > 0.01 * scale && push!(gaps, abs(a - b) / m)
+        end
+        @test maximum(gaps) < 1.0e-6
+        @test median(gaps) < 1.0e-9
+
+        # A pop's local updates read only finalised cells and write only non-finalised
+        # ones, so batching them across threads cannot change any of them. The field
+        # must therefore come out *bitwise* identical, not merely close. Anything that
+        # starts reading a `_CONSIDERED` value breaks this rather than degrading it.
+        qp_ser = quasipotential(
+            sys, grid, [0.0, 0.0];
+            band_radius = 8, regularization = 0.05, show_progress = false,
+            threaded = false,
+        )
+        @test all(map(===, qp_ser.U, U))
+        @test all(map(===, qp_ser.back_pointer, qp.back_pointer))
+    end
+
+    @testset "_sweep! drives a caller-seeded state with no extra keywords" begin
+        # Code that needs a custom seed (e.g. a Riccati tube around a limit cycle rather
+        # than a point attractor) builds `_OLIMState` itself and hands it to `_sweep!`.
+        # Keep that callable with just `verbose`/`show_progress`: the performance
+        # keywords added later must stay optional here, not just on `quasipotential`.
+        drift(u, p, t) = SVector(-u[1], -u[2])
+        sys = CoupledSDEs(drift, SA[0.0, 0.0]; noise_strength = 1.0)
+        grid = CartesianGrid((-1.0, 1.0, 21), (-1.0, 1.0, 21))
+        L = CT_._geometric_lagrangian(sys, Float64)
+        state = CT_._OLIMState(grid, Float64, L.Q_inv isa SMatrix)
+        src = CT_._source_cell(grid, SA[0.0, 0.0])
+        CT_._sweep!(
+            state, grid, src, sys, L, Val(5), Val(3);
+            verbose = false, show_progress = false,
+        )
+        @test all(isfinite, state.U)
+        @test all(>=(0), state.U)
+        @test state.U[src] == 0
+    end
+
+    @testset "incremental update matches the full rescan" begin
+        # A pop's only new candidates are the simplexes built from the popped cell;
+        # every other front simplex was already offered at an earlier pop. So updating
+        # from just those, on top of the value the cell already holds, must reproduce
+        # the full rescan. It cannot reproduce it bitwise, because the full rescan also
+        # re-evaluates *old* edges whose slope estimates have since improved -- but
+        # dropping a candidate can only leave `U` higher, so the difference has a sign.
+        gam = 0.5
+        drift(u, p, t) = SVector(u[2], -u[1] - gam * u[2])
+        gmat(u, p, t) = @SMatrix [0.0 0.0; 0.0 1.0]
+        sys = CoupledSDEs(
+            drift, SA[0.0, 0.0]; g = gmat,
+            noise_prototype = SMatrix{2, 2}(zeros(2, 2)),
+        )
+        grid = CartesianGrid((-1.5, 1.5, 41), (-1.5, 1.5, 41))
+        kw = (;
+            band_radius = 8, regularization = 0.02,
+            show_progress = false, threaded = false,
+        )
+        inc = quasipotential(sys, grid, [0.0, 0.0]; kw...)
+        full = quasipotential(sys, grid, [0.0, 0.0]; kw..., _full_rescan = true)
+
+        @test all(>=(0), filter(isfinite, inc.U))
+        @test count(isfinite, inc.U) == count(isfinite, full.U)
+        d = [a - b for (a, b) in zip(inc.U, full.U) if isfinite(a) && isfinite(b)]
+        scale = maximum(filter(isfinite, full.U))
+        # Dropping candidates can only raise U; allow a hair of slack for the cells
+        # where the two sweeps pick different (tied) winners and then diverge.
+        @test count(>=(0), d) > 0.99 * length(d)
+        @test maximum(d) < 0.01 * scale
+        @test -minimum(d) < 1.0e-3 * scale
+    end
+
+    @testset "prepared slopes match the per-λ Hermite path" begin
+        # `_edge_minimum` limits the slopes once per edge instead of at every λ. That is
+        # only sound because `_prepare_slopes` is idempotent: a prepared slope is never
+        # NaN and already lies in [0, 3Δ], so re-preparing it is a no-op.
+        for (U0, U1, m0, m1) in (
+                (0.0, 1.0, NaN, NaN), (1.0, 0.3, 5.0, -2.0), (0.5, 0.5, 0.2, -0.2),
+                (0.2, 0.9, 0.1, 4.0), (2.0, 1.0, NaN, 0.7),
+            )
+            s0, s1 = CT_._prepare_slopes(U0, U1, m0, m1)
+            @test CT_._prepare_slopes(U0, U1, s0, s1) === (s0, s1)
+            for λ in (0.0, 0.1, 0.5, 0.9, 1.0)
+                @test CT_._hermite_prepared(U0, U1, s0, s1, λ) ===
+                    CT_._hermite_U(U0, U1, m0, m1, λ)
+            end
+        end
     end
 
     @testset "regularized OLIM: van der Pol (non-equilibrium)" begin

--- a/test/largedeviations/quasipotential.jl
+++ b/test/largedeviations/quasipotential.jl
@@ -98,6 +98,41 @@ const CT_ = CriticalTransitions
         @test length(s3) == 32  # integer lattice points 0 < |δ|² ≤ 4 in ℤ³
     end
 
+    @testset "periodic stencil geometry" begin
+        nbox = (10, 7)
+        periodic = (true, false)
+        seam_left = CartesianIndex(1, 4)
+        seam_right = CartesianIndex(10, 4)
+
+        @test CT_._shift_in_bounds(
+            seam_left, CartesianIndex(-1, 0), nbox, periodic,
+        ) == seam_right
+        @test CT_._shift_in_bounds(
+            seam_right, CartesianIndex(1, 0), nbox, periodic,
+        ) == seam_left
+        @test CT_._shift_in_bounds(
+            seam_left, CartesianIndex(0, -4), nbox, periodic,
+        ) === nothing
+        @test CT_._is_chebyshev_adjacent(
+            seam_left, seam_right, nbox, periodic,
+        )
+        @test CT_._in_circular_stencil(
+            seam_left, seam_right, Val(1), nbox, periodic,
+        )
+
+        grid = CartesianGrid((0.0, 2.0, 10), (-1.0, 1.0, 7))
+        c = CT_._cell_center_near(grid, seam_right, seam_left, periodic)
+        @test c[1] == grid.centers[1][10] - 2.0
+        @test c[2] == grid.centers[2][4]
+
+        # The default remains hard-boundary behavior.
+        @test CT_._shift_in_bounds(
+            seam_left, CartesianIndex(-1, 0), nbox,
+        ) === nothing
+        @test !CT_._is_chebyshev_adjacent(seam_left, seam_right)
+        @test !CT_._in_circular_stencil(seam_left, seam_right, Val(1))
+    end
+
     @testset "OLIMState initialisation" begin
         grid = CartesianGrid((-1.0, 1.0, 10), (-1.0, 1.0, 10))
         st = CT_._OLIMState(grid, Float64)
@@ -105,6 +140,56 @@ const CT_ = CriticalTransitions
         @test all(==(CT_._UNKNOWN), st.status)
         @test count(st.front) == 0
         @test all(==(CT_.BackRef{2}()), st.back_pointer)
+        src = CartesianIndex(1, 1)
+        qp = CT_.QuasiPotential(st.U, st.back_pointer, src, grid)
+        @test qp.sources == [src]
+    end
+
+    @testset "public boundary and extended-attractor API" begin
+        grid = CartesianGrid((-π, π, 31), (-0.5, 0.5, 21))
+        j0 = 11
+        source_state = cell_center(grid, CartesianIndex(1, j0))
+        drift(z, p, t) = SVector(-sin(z[1] - source_state[1]), -z[2])
+        sys = CoupledSDEs(drift, source_state; noise_strength = 1.0)
+
+        bounded = quasipotential(
+            sys, grid, source_state;
+            bc = Reflecting(), band_radius = 5, near_source_layers = 0,
+            show_progress = false,
+        )
+        wrapped = quasipotential(
+            sys, grid, source_state;
+            bc = (Periodic(), Reflecting()), band_radius = 5,
+            near_source_layers = 0, show_progress = false,
+        )
+        @test wrapped.sources == [wrapped.source]
+        @test wrapped.source == CartesianIndex(1, j0)
+        # The last phase cell is adjacent to the source only on the periodic grid.
+        @test wrapped.U[end, j0] < bounded.U[end, j0] / 10
+        @test_throws ArgumentError quasipotential(
+            sys, grid, source_state;
+            bc = (Absorbing(), Reflecting()), show_progress = false,
+        )
+
+        phase_sources = [
+            SVector(θ, 0.0) for θ in grid.centers[1]
+        ]
+        cycle_drift(z, p, t) = SVector(1.0, -z[2])
+        cycle_sys = CoupledSDEs(cycle_drift, first(phase_sources); noise_strength = 1.0)
+        cycle_qp = quasipotential(
+            cycle_sys, grid, phase_sources;
+            bc = (Periodic(), Reflecting()), band_radius = 5,
+            show_progress = false,
+        )
+        expected_sources = [CartesianIndex(i, j0) for i in axes(cycle_qp.U, 1)]
+        @test cycle_qp.sources == expected_sources
+        @test all(iszero, cycle_qp.U[:, j0])
+        @test all(isfinite, cycle_qp.U)
+        @test_throws ArgumentError quasipotential(
+            cycle_sys, grid, phase_sources;
+            bc = (Periodic(), Reflecting()), near_source_layers = 1,
+            show_progress = false,
+        )
     end
 
     @testset "default_K" begin


### PR DESCRIPTION


- makes OLIM local updates incremental and threads each independent candidate batch
- adds per-axis `Reflecting()` / `Periodic()` topology to the public `quasipotential` API
- wraps stencil neighbours, simplex geometry, source seeding, and line integrals consistently across periodic seams
- accepts a collection of attractor states as a zero-valued source manifold, without derivative or curvature data
- preserves the existing fixed-point API and four-argument `QuasiPotential` constructor


A limit cycle is a zero-cost attractor manifold, not a point source. In phase-normal coordinates its phase axis must be periodic, while its transverse axis remains bounded. Previously this required constructing `_OLIMState` and driving `_sweep!` through private internals. It is now expressible through the public API:

```julia
qp = quasipotential(
    sys, grid, cycle_states;
    bc = (Periodic(), Reflecting()),
    near_source_layers = 0,
)
```
